### PR TITLE
feat: install specific Git branches/tags + optionally customise ktools build

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,16 +11,41 @@ pip install git+https://github.com/OasisLMF/water_seller.git
 ```
 
 ## Usage
+
 Water seller currently supports the following processes:
 
-### Local OasisLMF Installation
-This process installs the OasisLMF package locally and installs the required dependencies. This is essential if you
-want to run OasisLMF on a Mac ARM64 machine. To install the package locally use the following command:
+* Local installation of the MDK (`oasislmf` Python package)
 
+
+### Local MDK Installation
+
+This process installs the `oasislmf` package, and will install all of the required dependencies. Note that as part of the installation [ktools](https://github.com/OasisLMF/ktools), which is a C++ component separate from the Python component, is cloned and built from sources. Unlike `pip install oasislmf` (which calls [`python setup.py install`](https://github.com/OasisLMF/OasisLMF/blob/main/setup.py#L147), the `water_seller` tool allows the ktools build configuration and compilation to be customised at runtime.
+
+The base command is `ws-install-oasislmf` with optional arguments for build configuration and compilation provided after the `--extra` flag, as described below.
+```bash
+usage: ws-install-oasislmf [-h] [--extra] [--ktools-enable-osx] [--ktools-enable-o3] [-m MDK_BRANCH] [-k KTOOLS_BRANCH]
+                           [--ktools-disable-parquet]
+
+Example script using argparse
+
+options:
+  -h, --help            show this help message and exit
+  --extra               If extra OasisLMF requirements are installed Use this flag to set the value to True
+  --ktools-enable-osx   Enable OS X / Mac specific configuration / compilation options when building ktools
+  --ktools-enable-o3    Enable level 3 compiler optimisations when building ktools
+  -m MDK_BRANCH, --mdk-branch MDK_BRANCH
+                        (Optional) specific MDK Git branch or tag to install
+  -k KTOOLS_BRANCH, --ktools-branch KTOOLS_BRANCH
+                        (Optional) specific ktools Git branch or tag to install
+  --ktools-disable-parquet
+                        Disable Parquet option when configuring ktools
+```
+
+The basic usage is:
 ```bash
 ws-install-oasislmf --extra
 ```
-This will install the [OasisLMF](https://github.com/OasisLMF/OasisLMF) package directly from the ```master``` 
+which will install the [`oasislmf`](https://github.com/OasisLMF/OasisLMF) package directly from the ```master``` 
 branch of the [OasisLMF](https://github.com/OasisLMF/OasisLMF) github repository.
 
 To install a specific branch or release or tag use the same command as above with additional options as follows:
@@ -31,7 +56,9 @@ For example to install MDK release [`2.3.5`](https://github.com/OasisLMF/OasisLM
 ```bash
 ws-install-oasislmf --extra --mdk-branch 2.3.5 --ktools-branch v3.12.3 [--ktools-disable-parquet]
 ```
-The optional boolean `--ktools-disable-parquet` disables the Parquet flag when configuring ktools, e.g.:
-```bash
-[/build/path/to/ktools] $ ./configure ... --disable-parquet
-```
+
+To customise the ktools build configuration and/or compilation use the following flags (after `--extra`):
+
+* `--ktools-enable-osx` - for Mac-specific customisations
+* `--ktools-enable-o3` - for [level 3 C++ compiler optimisations](https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html#index-O3)
+* `--ktools-disable-parquet` - for disabling the Parquet flag when configuring ktools

--- a/README.md
+++ b/README.md
@@ -1,1 +1,37 @@
-# water_seller
+
+# Water Seller
+
+This is a tool for handling local processes in order to run OasisLMF products. 
+
+## Installation
+To install the package with pip use the following command:
+
+```bash
+pip install git+https://github.com/OasisLMF/water_seller.git     
+```
+
+## Usage
+Water seller currently supports the following processes:
+
+### Local OasisLMF Installation
+This process installs the OasisLMF package locally and installs the required dependencies. This is essential if you
+want to run OasisLMF on a Mac ARM64 machine. To install the package locally use the following command:
+
+```bash
+ws-install-oasislmf --extra
+```
+This will install the [OasisLMF](https://github.com/OasisLMF/OasisLMF) package directly from the ```master``` 
+branch of the [OasisLMF](https://github.com/OasisLMF/OasisLMF) github repository.
+
+To install a specific branch or release or tag use the same command as above with additional options as follows:
+```bash
+ws-install-oasislmf --extra --mdk-branch <MDK branch or release or tag name> --ktools-branch <ktools branch or release or tag name> [--ktools-disable-parquet]
+```
+For example to install MDK release [`2.3.5`](https://github.com/OasisLMF/OasisLMF/releases/tag/2.3.5), which is linked to ktools release [`v3.12.3`](https://github.com/OasisLMF/ktools/releases/tag/v3.12.3) use:
+```bash
+ws-install-oasislmf --extra --mdk-branch 2.3.5 --ktools-branch v3.12.3 [--ktools-disable-parquet]
+```
+The optional boolean `--ktools-disable-parquet` disables the Parquet flag when configuring ktools, e.g.:
+```bash
+[/build/path/to/ktools] $ ./configure ... --disable-parquet
+```

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setup(
     ],
     entry_points={
         "console_scripts": [
-            "ws-install=water_seller.install.oasislmf.entry_points.install:main"
+            "ws-install-oasislmf=water_seller.install.oasislmf.entry_points.install:main"
         ]
     },
 )

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='water-seller',
-    version='0.1.0',
+    version='0.2.0',
     author='maxwell flitton',
     author_email='maxwellflitton@gmail.com',
     packages=find_packages(exclude=("tests",)),

--- a/water_seller/install/oasislmf/entry_points/install.py
+++ b/water_seller/install/oasislmf/entry_points/install.py
@@ -26,6 +26,22 @@ def main() -> None:
     )
 
     parser.add_argument(
+        "--ktools-enable-osx",
+        required=False,
+        action="store_true",
+        default=False,
+        help="Enable OS X / Mac specific configuration / compilation options when building ktools"
+    )
+
+    parser.add_argument(
+        "--ktools-enable-o3",
+        required=False,
+        action="store_true",
+        default=True,
+        help="Enable level 3 compiler optimisations when building ktools"
+    )
+
+    parser.add_argument(
         "-m", "--mdk-branch",
         required=False,
         type=str,
@@ -66,7 +82,11 @@ def main() -> None:
     )
     clone_ktools.clone_repo()
 
-    compile_ktools: CompileKtools = CompileKtools(ktools_path=clone_ktools.package_path, disable_parquet=args.ktools_disable_parquet)
+    compile_ktools: CompileKtools = CompileKtools(
+        ktools_path=clone_ktools.package_path,
+        enable_osx=args.ktools_enable_osx,
+        enable_o3=args.ktools_enable_o3,
+        disable_parquet=args.ktools_disable_parquet)
     compile_ktools.compile()
 
     package_ktools: PackageKtools = PackageKtools(ktools_path=clone_ktools.package_path)

--- a/water_seller/install/oasislmf/entry_points/install.py
+++ b/water_seller/install/oasislmf/entry_points/install.py
@@ -3,6 +3,7 @@ This file defines the entry point for building ktools locally and installing Oas
 """
 import os
 import shutil
+import argparse
 
 from water_seller.install.oasislmf.steps.clone_repos import CloneRepos
 from water_seller.install.oasislmf.steps.compile_ktools import CompileKtools
@@ -14,6 +15,42 @@ def main() -> None:
     """
     The main function for building ktools and installing oasislmf.
     """
+    parser = argparse.ArgumentParser(description="Example script using argparse")
+
+    # Add the extra flag, store_true sets the value to True if the flag is present, otherwise False
+    parser.add_argument(
+        "--extra",
+        dest="extra",
+        action="store_true",
+        help="If extra OasisLMF requirements are installed Use this flag to set the value to True"
+    )
+
+    parser.add_argument(
+        "-m", "--mdk-branch",
+        required=False,
+        type=str,
+        default=None,
+        help="(Optional) specific MDK Git branch or tag to install"
+    )
+
+    parser.add_argument(
+        "-k", "--ktools-branch",
+        required=False,
+        type=str,
+        default=None,
+        help="(Optional) specific ktools Git branch or tag to install"
+    )
+
+    parser.add_argument(
+        "--ktools-disable-parquet",
+        required=False,
+        action="store_true",
+        default=False,
+        help="Disable Parquet option when configuring ktools"
+    )
+
+    args = parser.parse_args()
+
     root_path: str = str(os.getcwd())
     stash_path: str = str(os.path.join(root_path, "stash"))
 
@@ -24,11 +61,12 @@ def main() -> None:
     clone_ktools: CloneRepos = CloneRepos(
         root_path=root_path,
         git_url="https://github.com/OasisLMF/ktools.git",
-        package_name="ktools"
+        package_name="ktools",
+        branch=args.ktools_branch
     )
     clone_ktools.clone_repo()
 
-    compile_ktools: CompileKtools = CompileKtools(ktools_path=clone_ktools.package_path)
+    compile_ktools: CompileKtools = CompileKtools(ktools_path=clone_ktools.package_path, disable_parquet=args.ktools_disable_parquet)
     compile_ktools.compile()
 
     package_ktools: PackageKtools = PackageKtools(ktools_path=clone_ktools.package_path)
@@ -37,10 +75,13 @@ def main() -> None:
     clone_oasislmf: CloneRepos = CloneRepos(
         root_path=root_path,
         git_url="https://github.com/OasisLMF/OasisLMF.git",
-        package_name="oasislmf"
+        package_name="oasislmf",
+        branch=args.mdk_branch
     )
     clone_oasislmf.clone_repo()
 
     install_oasislmf: InstallOasisLmf = InstallOasisLmf(root_path=clone_oasislmf.package_path,
-                                                        ktools_path=clone_ktools.package_path)
+                                                        ktools_path=clone_ktools.package_path,
+                                                        extra=args.extra)
     install_oasislmf.install()
+    shutil.rmtree(stash_path)

--- a/water_seller/install/oasislmf/steps/clone_repos.py
+++ b/water_seller/install/oasislmf/steps/clone_repos.py
@@ -14,7 +14,7 @@ class CloneRepos:
         git_url: the url of the git repo to clone
         package_name: the name of the package to clone
     """
-    def __init__(self, root_path: str, git_url: str, package_name: str) -> None:
+    def __init__(self, root_path: str, git_url: str, package_name: str, branch: str = None) -> None:
         """
         The constructor for the CloneRepos class.
 
@@ -22,9 +22,10 @@ class CloneRepos:
         :param git_url: the url of the git repo to clone
         :param package_name: the name of the package to clone
         """
-        self._root_path: str = root_path
-        self.git_url: str = git_url
-        self.package_name: str = package_name
+        self._root_path = root_path
+        self.git_url = git_url
+        self.package_name = package_name
+        self.branch = branch
 
     def clone_repo(self) -> None:
         """
@@ -32,7 +33,9 @@ class CloneRepos:
 
         :return: None
         """
-        TerminalCommand(f"cd {self.root_path} && git clone {self.git_url}").wait()
+        clone_options = "" if not self.branch else f"--depth 1 --branch {self.branch}"
+        TerminalCommand(f"echo 'Cloning {self.git_url}@{self.branch if self.branch else '''latest'''}'").wait()
+        TerminalCommand(f"cd {self.root_path} && git clone {clone_options} {self.git_url}").wait()
 
     @property
     def root_path(self) -> str:

--- a/water_seller/install/oasislmf/steps/compile_ktools.py
+++ b/water_seller/install/oasislmf/steps/compile_ktools.py
@@ -13,13 +13,14 @@ class CompileKtools:
     Attributes:
         ktools_path: the path to the ktools directory
     """
-    def __init__(self, ktools_path: str) -> None:
+    def __init__(self, ktools_path: str, disable_parquet: bool = False) -> None:
         """
         The constructor for the CompileKtools class.
 
         :param ktools_path: the path to the ktools directory
         """
         self.ktools_path: str = ktools_path
+        self.disable_parquet = disable_parquet
 
     def compile(self) -> None:
         """
@@ -29,7 +30,7 @@ class CompileKtools:
         """
         TerminalCommand(f"cd {self.ktools_path} && ./autogen.sh").wait()
         TerminalCommand(
-            f"cd {self.ktools_path} && ./configure --enable-osx --enable-o3 --prefix={self.bin_path}"
+            f"cd {self.ktools_path} && ./configure --enable-osx --enable-o3 {'--disable-parquet' if self.disable_parquet else ''} --prefix={self.bin_path}"
         ).wait()
         TerminalCommand(f"cd {self.ktools_path} && make check").wait()
         TerminalCommand(f"cd {self.ktools_path} && make install").wait()

--- a/water_seller/install/oasislmf/steps/compile_ktools.py
+++ b/water_seller/install/oasislmf/steps/compile_ktools.py
@@ -13,13 +13,20 @@ class CompileKtools:
     Attributes:
         ktools_path: the path to the ktools directory
     """
-    def __init__(self, ktools_path: str, disable_parquet: bool = False) -> None:
+    def __init__(
+        self,
+        ktools_path: str,
+        enable_osx: bool = False,
+        enable_o3: bool = True,
+        disable_parquet: bool = False) -> None:
         """
         The constructor for the CompileKtools class.
 
         :param ktools_path: the path to the ktools directory
         """
         self.ktools_path: str = ktools_path
+        self.enable_osx = enable_osx
+        self.enable_o3 = enable_o3
         self.disable_parquet = disable_parquet
 
     def compile(self) -> None:
@@ -30,7 +37,12 @@ class CompileKtools:
         """
         TerminalCommand(f"cd {self.ktools_path} && ./autogen.sh").wait()
         TerminalCommand(
-            f"cd {self.ktools_path} && ./configure --enable-osx --enable-o3 {'--disable-parquet' if self.disable_parquet else ''} --prefix={self.bin_path}"
+            f"cd {self.ktools_path} "
+            "&& ./configure "
+            f"{'--enable-osx' if self.enable_osx else ''} "
+            f"{'--enable-o3' if self.enable_o3 else ''}  "
+            f"{'--disable-parquet' if self.disable_parquet else ''} "
+            f"--prefix={self.bin_path}"
         ).wait()
         TerminalCommand(f"cd {self.ktools_path} && make check").wait()
         TerminalCommand(f"cd {self.ktools_path} && make install").wait()

--- a/water_seller/install/oasislmf/steps/install_oasislmf.py
+++ b/water_seller/install/oasislmf/steps/install_oasislmf.py
@@ -2,6 +2,7 @@
 This file defines the InstallOasisLmf class is used to install the oasislmf package.
 """
 from distutils import util
+from pathlib import Path
 
 from gerund.commands.terminal_command import TerminalCommand
 
@@ -24,8 +25,8 @@ class InstallOasisLmf:
         :param ktools_path: the path to the root directory of the cloned ktools repo
         :param extra: whether to install the extra packages
         """
-        self.root_path: str = root_path
-        self.ktools_path: str = ktools_path
+        self.root_path = Path(root_path).resolve()
+        self.ktools_path = Path(ktools_path).resolve()
         self.platform: str = util.get_platform().replace("-", "_").replace(".", "_")
         self.extra: bool = extra
 
@@ -38,16 +39,16 @@ class InstallOasisLmf:
         TerminalCommand("pip install pip-tools").wait()
 
         env_vars = {
-            "KTOOLS_TAR_FILE_DIR": self.ktools_path
+            "KTOOLS_TAR_FILE_DIR": str(self.ktools_path)
         }
         TerminalCommand(
-            f"cd {self.root_path} && python setup.py install bdist_wheel --plat-name {self.platform}",
+            f"cd {str(self.root_path)} && python setup.py install bdist_wheel --plat-name {self.platform}",
             environment_variables=env_vars
         ).wait()
         TerminalCommand(
-            f"cd {self.root_path} && pip install -r requirements-package.in"
+            f"cd {str(self.root_path)} && pip install -r requirements-package.in"
         ).wait()
         if self.extra is True:
             TerminalCommand(
-                f"cd {self.root_path} && pip install -r optional-package.in"
+                f"cd {str(self.root_path)} && pip install -r optional-package.in"
             ).wait()

--- a/water_seller/install/oasislmf/steps/install_oasislmf.py
+++ b/water_seller/install/oasislmf/steps/install_oasislmf.py
@@ -1,17 +1,40 @@
-import os
+"""
+This file defines the InstallOasisLmf class is used to install the oasislmf package.
+"""
+from distutils import util
 
 from gerund.commands.terminal_command import TerminalCommand
-from distutils import util
 
 
 class InstallOasisLmf:
+    """
+    The InstallOasisLmf class is used to install the oasislmf package.
 
-    def __init__(self, root_path: str, ktools_path: str) -> None:
+    Attributes:
+        root_path: the path to the root directory of the cloned oasislmf repo
+        ktools_path: the path to the root directory of the cloned ktools repo
+        platform: the platform the ktools are being compiled for
+        extra: whether to install the extra packages
+    """
+    def __init__(self, root_path: str, ktools_path: str, extra: bool = True) -> None:
+        """
+        The constructor for the InstallOasisLmf class.
+
+        :param root_path: the path to the root directory of the cloned oasislmf repo
+        :param ktools_path: the path to the root directory of the cloned ktools repo
+        :param extra: whether to install the extra packages
+        """
         self.root_path: str = root_path
         self.ktools_path: str = ktools_path
         self.platform: str = util.get_platform().replace("-", "_").replace(".", "_")
+        self.extra: bool = extra
 
     def install(self) -> None:
+        """
+        Installs the oasislmf package.
+
+        :return: None
+        """
         TerminalCommand("pip install pip-tools").wait()
 
         env_vars = {
@@ -21,3 +44,10 @@ class InstallOasisLmf:
             f"cd {self.root_path} && python setup.py install bdist_wheel --plat-name {self.platform}",
             environment_variables=env_vars
         ).wait()
+        TerminalCommand(
+            f"cd {self.root_path} && pip install -r requirements-package.in"
+        ).wait()
+        if self.extra is True:
+            TerminalCommand(
+                f"cd {self.root_path} && pip install -r optional-package.in"
+            ).wait()

--- a/water_seller/install/oasislmf/steps/package_ktools.py
+++ b/water_seller/install/oasislmf/steps/package_ktools.py
@@ -16,6 +16,11 @@ class PackageKtools:
         platform: the platform the ktools are being compiled for
     """
     def __init__(self, ktools_path: str) -> None:
+        """
+        The constructor for the PackageKtools class.
+
+        :param ktools_path: the path to the ktools directory
+        """
         self.ktools_path: str = ktools_path
         self.platform: str = util.get_platform().replace("-", "_").replace(".", "_")
 


### PR DESCRIPTION
Changes to support:

* installing custom branches and tags (via `clone --depth 1 --branch <branch | tag> <url>`)
* additional options to customise ktools build configuration and compilation - `--ktools-enable-osx`, `--ktools-enable-o3`, `--ktools-disable-parquet`

To test:

1. `pip install` this branch using:
```bash
pip uninstall -y water_seller && pip install git+https://github.com/sr-murthy/water_seller@feat-cli-enhancements
```
2. Run the installer using:
```bash
ws-install-oasislmf --extra [--mdk-branch <branch | tag>] [--ktools-branch <branch | tag>] [--ktools-enable-osx] [--ktools-enable-o3] [--ktools-disable-parquet]
```
3. Verify the package was installed:
```bash
pip show oasislmf
```
